### PR TITLE
Add -registerDefaults: method

### DIFF
--- a/LUKeychainAccess.xcodeproj/project.pbxproj
+++ b/LUKeychainAccess.xcodeproj/project.pbxproj
@@ -91,7 +91,10 @@
 				0226874316BAD892008FC8FA /* Products */,
 				028518F716BADB90000C43F0 /* Pods-test.xcconfig */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
 		};
 		0226874316BAD892008FC8FA /* Products */ = {
 			isa = PBXGroup;

--- a/LUKeychainAccess/LUKeychainAccess.h
+++ b/LUKeychainAccess/LUKeychainAccess.h
@@ -13,6 +13,7 @@
 - (NSString *)stringForKey:(NSString *)key;
 
 // Setters
+- (void)registerDefaults:(NSDictionary *)dictionary;
 - (void)setBool:(BOOL)value forKey:(NSString *)key;
 - (void)setData:(NSData *)data forKey:(NSString *)key;
 - (void)setDouble:(double)value forKey:(NSString *)key;

--- a/LUKeychainAccess/LUKeychainAccess.m
+++ b/LUKeychainAccess/LUKeychainAccess.m
@@ -71,6 +71,18 @@
 
 #pragma mark - Setters
 
+- (void)registerDefaults:(NSDictionary *)dictionary {
+  for (NSString *key in [dictionary allKeys]) {
+    if (![self objectForKey:key]) {
+      if ([dictionary[key] isKindOfClass:[NSString class]]) {
+        [self setString:dictionary[key] forKey:key];
+      } else {
+        [self setObject:dictionary[key] forKey:key];
+      }
+    }
+  }
+}
+
 - (void)setBool:(BOOL)value forKey:(NSString *)key {
   [self setObject:@(value) forKey:key];
 }

--- a/UnitTests/LUKeychainAccessSpec.m
+++ b/UnitTests/LUKeychainAccessSpec.m
@@ -125,6 +125,48 @@ describe(@"LUKeychainAccess", ^{
 
   // Setters
 
+  describe(@"registerDefaults:", ^{
+    NSDictionary *existingDefaults = @{@"existingKey" : @"existingValue"};
+    NSArray *newDefaultKeys = @[@"newKey", @"foo", @"bar"];
+
+    beforeEach(^{
+      for (NSString *newKey in newDefaultKeys) {
+        [keychainAccess setObject:nil forKey:newKey];
+      }
+
+      for (NSString *key in [existingDefaults allKeys]) {
+        [[keychainAccess stubAndReturn:existingDefaults[key]] objectForKey:key];
+      }
+    });
+
+    it(@"sets strings using setString: instead of setObject:", ^{
+      NSString *newValue = @"newValue";
+      [[[keychainAccess should] receive] setString:newValue forKey:@"newKey"];
+      [keychainAccess registerDefaults:@{@"newKey": newValue}];
+    });
+
+    it(@"sets other data types via setObject:", ^{
+      [[[keychainAccess should] receive] setObject:@1 forKey:@"newKey"];
+      [keychainAccess registerDefaults:@{@"newKey" : @1}];
+    });
+
+    it(@"doesn't overwrite existing values", ^{
+      [[[keychainAccess shouldNot] receive] setObject:@YES forKey:@"existingKey"];
+      [keychainAccess registerDefaults:@{@"existingKey" : @YES}];
+    });
+
+    it(@"sets the value for new keys", ^{
+      [[[keychainAccess should] receive] setObject:@YES forKey:@"newKey"];
+      [keychainAccess registerDefaults:@{@"newKey" : @YES}];
+    });
+
+    it(@"can set multiple keys", ^{
+      [[[keychainAccess should] receive] setObject:@YES forKey:@"foo"];
+      [[[keychainAccess should] receive] setObject:@100 forKey:@"bar"];
+      [keychainAccess registerDefaults:@{@"foo" : @YES, @"bar" : @100}];
+    });
+  });
+
   describe(@"setBool:forKey:", ^{
     NSString *key = @"boolTest";
 


### PR DESCRIPTION
Useful way to set a bunch of default values into the keychain without
overwriting existing values if they exist.

I also set the indentation level on the Xcode project just for my own sanity
