### PR TITLE
Add Framework target

### DIFF
--- a/LUKeychainAccess.xcodeproj/project.pbxproj
+++ b/LUKeychainAccess.xcodeproj/project.pbxproj
@@ -7,50 +7,28 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0226874616BAD892008FC8FA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0226874516BAD892008FC8FA /* Foundation.framework */; };
-		0226874B16BAD892008FC8FA /* LUKeychainAccess.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0226874A16BAD892008FC8FA /* LUKeychainAccess.h */; };
-		0226874D16BAD892008FC8FA /* LUKeychainAccess.m in Sources */ = {isa = PBXBuildFile; fileRef = 0226874C16BAD892008FC8FA /* LUKeychainAccess.m */; };
 		0226875816BAD892008FC8FA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0226874516BAD892008FC8FA /* Foundation.framework */; };
-		0226875B16BAD892008FC8FA /* libLUKeychainAccess.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0226874216BAD892008FC8FA /* libLUKeychainAccess.a */; };
 		0226876F16BAD991008FC8FA /* LUKeychainAccessSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 0226876E16BAD991008FC8FA /* LUKeychainAccessSpec.m */; };
-		0226877116BAD99F008FC8FA /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0226877016BAD99F008FC8FA /* Security.framework */; };
 		0226877216BAD9AC008FC8FA /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0226877016BAD99F008FC8FA /* Security.framework */; };
 		0226877416BADA41008FC8FA /* libPods-test.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0226877316BADA41008FC8FA /* libPods-test.a */; };
 		02757704180892C1008B3C12 /* LUKeychainServicesSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 02757702180892B1008B3C12 /* LUKeychainServicesSpec.m */; };
-		028CCA2118084AAF00267911 /* LUKeychainServices.m in Sources */ = {isa = PBXBuildFile; fileRef = 028CCA2018084AAF00267911 /* LUKeychainServices.m */; };
 		02ABC53418087D9100A13931 /* LUTestErrorHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 02ABC53318087D9100A13931 /* LUTestErrorHandler.m */; };
+		F8120D2C1B065C32004EBEF3 /* LUKeychainAccessAccessibility.h in Headers */ = {isa = PBXBuildFile; fileRef = F8120D2B1B065C32004EBEF3 /* LUKeychainAccessAccessibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F8B3FC251B027D4A008AF919 /* LUKeychainAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 0226874A16BAD892008FC8FA /* LUKeychainAccess.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F8B3FC261B027D52008AF919 /* LUKeychainAccess.m in Sources */ = {isa = PBXBuildFile; fileRef = 0226874C16BAD892008FC8FA /* LUKeychainAccess.m */; };
+		F8B3FC271B027D52008AF919 /* LUKeychainErrorHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 02ABC53118087D0100A13931 /* LUKeychainErrorHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F8B3FC281B027D52008AF919 /* LUKeychainServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 028CCA1F18084AAF00267911 /* LUKeychainServices.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F8B3FC291B027D52008AF919 /* LUKeychainServices.m in Sources */ = {isa = PBXBuildFile; fileRef = 028CCA2018084AAF00267911 /* LUKeychainServices.m */; };
+		F8B3FC2A1B027D6D008AF919 /* LUKeychainAccess-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 0226874916BAD892008FC8FA /* LUKeychainAccess-Prefix.pch */; };
+		F8B3FC2C1B027DE1008AF919 /* LUKeychainAccess.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8B3FC0C1B027CBA008AF919 /* LUKeychainAccess.framework */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		0226875916BAD892008FC8FA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0226873A16BAD892008FC8FA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0226874116BAD892008FC8FA;
-			remoteInfo = LUKeychainAccess;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		0226874016BAD892008FC8FA /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "include/${PRODUCT_NAME}";
-			dstSubfolderSpec = 16;
-			files = (
-				0226874B16BAD892008FC8FA /* LUKeychainAccess.h in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
-		0226874216BAD892008FC8FA /* libLUKeychainAccess.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libLUKeychainAccess.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		0226874516BAD892008FC8FA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		0226874916BAD892008FC8FA /* LUKeychainAccess-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LUKeychainAccess-Prefix.pch"; sourceTree = "<group>"; };
 		0226874A16BAD892008FC8FA /* LUKeychainAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LUKeychainAccess.h; sourceTree = "<group>"; };
 		0226874C16BAD892008FC8FA /* LUKeychainAccess.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LUKeychainAccess.m; sourceTree = "<group>"; };
-		0226875316BAD892008FC8FA /* UnitTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = UnitTests.octest; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0226875316BAD892008FC8FA /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0226876E16BAD991008FC8FA /* LUKeychainAccessSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LUKeychainAccessSpec.m; sourceTree = "<group>"; };
 		0226877016BAD99F008FC8FA /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		0226877316BADA41008FC8FA /* libPods-test.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-test.a"; path = "Pods/build/Release-iphoneos/libPods-test.a"; sourceTree = "<group>"; };
@@ -63,26 +41,27 @@
 		21D80151083ABFD1C71383C6 /* libPods-UnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-UnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		666BEC4EDA7D51370C0F76F5 /* Pods-test.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-test.release.xcconfig"; path = "Pods/Target Support Files/Pods-test/Pods-test.release.xcconfig"; sourceTree = "<group>"; };
 		F3AB6C26D5ACBCCA1BE08225 /* Pods-test.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-test.debug.xcconfig"; path = "Pods/Target Support Files/Pods-test/Pods-test.debug.xcconfig"; sourceTree = "<group>"; };
+		F8120D2B1B065C32004EBEF3 /* LUKeychainAccessAccessibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LUKeychainAccessAccessibility.h; sourceTree = "<group>"; };
+		F8B3FC0C1B027CBA008AF919 /* LUKeychainAccess.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LUKeychainAccess.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8B3FC2B1B027D9D008AF919 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		0226873F16BAD892008FC8FA /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0226877116BAD99F008FC8FA /* Security.framework in Frameworks */,
-				0226874616BAD892008FC8FA /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		0226874F16BAD892008FC8FA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F8B3FC2C1B027DE1008AF919 /* LUKeychainAccess.framework in Frameworks */,
 				0226877416BADA41008FC8FA /* libPods-test.a in Frameworks */,
 				0226877216BAD9AC008FC8FA /* Security.framework in Frameworks */,
 				0226875816BAD892008FC8FA /* Foundation.framework in Frameworks */,
-				0226875B16BAD892008FC8FA /* libLUKeychainAccess.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8B3FC081B027CBA008AF919 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -106,8 +85,8 @@
 		0226874316BAD892008FC8FA /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				0226874216BAD892008FC8FA /* libLUKeychainAccess.a */,
-				0226875316BAD892008FC8FA /* UnitTests.octest */,
+				0226875316BAD892008FC8FA /* UnitTests.xctest */,
+				F8B3FC0C1B027CBA008AF919 /* LUKeychainAccess.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -128,9 +107,10 @@
 			children = (
 				0226874A16BAD892008FC8FA /* LUKeychainAccess.h */,
 				0226874C16BAD892008FC8FA /* LUKeychainAccess.m */,
-				02ABC53118087D0100A13931 /* LUKeychainErrorHandler.h */,
 				028CCA1F18084AAF00267911 /* LUKeychainServices.h */,
 				028CCA2018084AAF00267911 /* LUKeychainServices.m */,
+				F8120D2B1B065C32004EBEF3 /* LUKeychainAccessAccessibility.h */,
+				02ABC53118087D0100A13931 /* LUKeychainErrorHandler.h */,
 				0226874816BAD892008FC8FA /* Supporting Files */,
 			);
 			path = LUKeychainAccess;
@@ -139,6 +119,7 @@
 		0226874816BAD892008FC8FA /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				F8B3FC2B1B027D9D008AF919 /* Info.plist */,
 				0226874916BAD892008FC8FA /* LUKeychainAccess-Prefix.pch */,
 			);
 			name = "Supporting Files";
@@ -167,24 +148,22 @@
 		};
 /* End PBXGroup section */
 
-/* Begin PBXNativeTarget section */
-		0226874116BAD892008FC8FA /* LUKeychainAccess */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 0226876716BAD892008FC8FA /* Build configuration list for PBXNativeTarget "LUKeychainAccess" */;
-			buildPhases = (
-				0226873E16BAD892008FC8FA /* Sources */,
-				0226873F16BAD892008FC8FA /* Frameworks */,
-				0226874016BAD892008FC8FA /* CopyFiles */,
+/* Begin PBXHeadersBuildPhase section */
+		F8B3FC091B027CBA008AF919 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8B3FC281B027D52008AF919 /* LUKeychainServices.h in Headers */,
+				F8B3FC251B027D4A008AF919 /* LUKeychainAccess.h in Headers */,
+				F8120D2C1B065C32004EBEF3 /* LUKeychainAccessAccessibility.h in Headers */,
+				F8B3FC2A1B027D6D008AF919 /* LUKeychainAccess-Prefix.pch in Headers */,
+				F8B3FC271B027D52008AF919 /* LUKeychainErrorHandler.h in Headers */,
 			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = LUKeychainAccess;
-			productName = LUKeychainAccess;
-			productReference = 0226874216BAD892008FC8FA /* libLUKeychainAccess.a */;
-			productType = "com.apple.product-type.library.static";
+			runOnlyForDeploymentPostprocessing = 0;
 		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
 		0226875216BAD892008FC8FA /* UnitTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0226876A16BAD892008FC8FA /* Build configuration list for PBXNativeTarget "UnitTests" */;
@@ -199,12 +178,29 @@
 			buildRules = (
 			);
 			dependencies = (
-				0226875A16BAD892008FC8FA /* PBXTargetDependency */,
 			);
 			name = UnitTests;
 			productName = LUKeychainAccessTests;
-			productReference = 0226875316BAD892008FC8FA /* UnitTests.octest */;
+			productReference = 0226875316BAD892008FC8FA /* UnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		F8B3FC0B1B027CBA008AF919 /* LUKeychainAccess */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F8B3FC1F1B027CBB008AF919 /* Build configuration list for PBXNativeTarget "LUKeychainAccess" */;
+			buildPhases = (
+				F8B3FC071B027CBA008AF919 /* Sources */,
+				F8B3FC081B027CBA008AF919 /* Frameworks */,
+				F8B3FC091B027CBA008AF919 /* Headers */,
+				F8B3FC0A1B027CBA008AF919 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LUKeychainAccess;
+			productName = LUKeychainAccess;
+			productReference = F8B3FC0C1B027CBA008AF919 /* LUKeychainAccess.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -215,6 +211,11 @@
 				LastTestingUpgradeCheck = 0610;
 				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = SCVNGR;
+				TargetAttributes = {
+					F8B3FC0B1B027CBA008AF919 = {
+						CreatedOnToolsVersion = 6.3.1;
+					};
+				};
 			};
 			buildConfigurationList = 0226873D16BAD892008FC8FA /* Build configuration list for PBXProject "LUKeychainAccess" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -228,7 +229,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				0226874116BAD892008FC8FA /* LUKeychainAccess */,
+				F8B3FC0B1B027CBA008AF919 /* LUKeychainAccess */,
 				0226875216BAD892008FC8FA /* UnitTests */,
 			);
 		};
@@ -236,6 +237,13 @@
 
 /* Begin PBXResourcesBuildPhase section */
 		0226875016BAD892008FC8FA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8B3FC0A1B027CBA008AF919 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -291,15 +299,6 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		0226873E16BAD892008FC8FA /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				028CCA2118084AAF00267911 /* LUKeychainServices.m in Sources */,
-				0226874D16BAD892008FC8FA /* LUKeychainAccess.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		0226874E16BAD892008FC8FA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -310,15 +309,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		0226875A16BAD892008FC8FA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 0226874116BAD892008FC8FA /* LUKeychainAccess */;
-			targetProxy = 0226875916BAD892008FC8FA /* PBXContainerItemProxy */;
+		F8B3FC071B027CBA008AF919 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8B3FC291B027D52008AF919 /* LUKeychainServices.m in Sources */,
+				F8B3FC261B027D52008AF919 /* LUKeychainAccess.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
-/* End PBXTargetDependency section */
+/* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
 		0226876516BAD892008FC8FA /* Debug */ = {
@@ -376,36 +376,14 @@
 			};
 			name = Release;
 		};
-		0226876816BAD892008FC8FA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DSTROOT = /tmp/LUKeychainAccess.dst;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "LUKeychainAccess/LUKeychainAccess-Prefix.pch";
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		0226876916BAD892008FC8FA /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DSTROOT = /tmp/LUKeychainAccess.dst;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "LUKeychainAccess/LUKeychainAccess-Prefix.pch";
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
 		0226876B16BAD892008FC8FA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F3AB6C26D5ACBCCA1BE08225 /* Pods-test.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "LUKeychainAccess/LUKeychainAccess-Prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -414,9 +392,87 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 666BEC4EDA7D51370C0F76F5 /* Pods-test.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "LUKeychainAccess/LUKeychainAccess-Prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		F8B3FC201B027CBB008AF919 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = LUKeychainAccess/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		F8B3FC211B027CBB008AF919 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = LUKeychainAccess/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
@@ -432,20 +488,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		0226876716BAD892008FC8FA /* Build configuration list for PBXNativeTarget "LUKeychainAccess" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0226876816BAD892008FC8FA /* Debug */,
-				0226876916BAD892008FC8FA /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		0226876A16BAD892008FC8FA /* Build configuration list for PBXNativeTarget "UnitTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0226876B16BAD892008FC8FA /* Debug */,
 				0226876C16BAD892008FC8FA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F8B3FC1F1B027CBB008AF919 /* Build configuration list for PBXNativeTarget "LUKeychainAccess" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F8B3FC201B027CBB008AF919 /* Debug */,
+				F8B3FC211B027CBB008AF919 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/LUKeychainAccess.xcodeproj/xcshareddata/xcschemes/LUKeychainAccess.xcscheme
+++ b/LUKeychainAccess.xcodeproj/xcshareddata/xcschemes/LUKeychainAccess.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F8B3FC0B1B027CBA008AF919"
+               BuildableName = "LUKeychainAccess.framework"
+               BlueprintName = "LUKeychainAccess"
+               ReferencedContainer = "container:LUKeychainAccess.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0226875216BAD892008FC8FA"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:LUKeychainAccess.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0226875216BAD892008FC8FA"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:LUKeychainAccess.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8B3FC0B1B027CBA008AF919"
+            BuildableName = "LUKeychainAccess.framework"
+            BlueprintName = "LUKeychainAccess"
+            ReferencedContainer = "container:LUKeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8B3FC0B1B027CBA008AF919"
+            BuildableName = "LUKeychainAccess.framework"
+            BlueprintName = "LUKeychainAccess"
+            ReferencedContainer = "container:LUKeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8B3FC0B1B027CBA008AF919"
+            BuildableName = "LUKeychainAccess.framework"
+            BlueprintName = "LUKeychainAccess"
+            ReferencedContainer = "container:LUKeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LUKeychainAccess/Info.plist
+++ b/LUKeychainAccess/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.SCVNGR.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/LUKeychainAccess/LUKeychainAccess.h
+++ b/LUKeychainAccess/LUKeychainAccess.h
@@ -1,19 +1,18 @@
 #import <Foundation/Foundation.h>
 #import "LUKeychainErrorHandler.h"
+#import "LUKeychainServices.h"
+#import "LUKeychainAccessAccessibility.h"
+
+//! Project version number for LUKeychainAccess.
+FOUNDATION_EXPORT double LUKeychainAccessVersionNumber;
+
+//! Project version string for LUKeychainAccess.
+FOUNDATION_EXPORT const unsigned char LUKeychainAccessVersionString[];
 
 extern NSString *LUKeychainAccessErrorDomain;
 
 typedef NS_ENUM(NSInteger, LUKeychainAccessError) {
   LUKeychainAccessInvalidArchiveError
-};
-
-typedef NS_ENUM(NSInteger, LUKeychainAccessAccessibility) {
-  LUKeychainAccessAttrAccessibleAfterFirstUnlock,
-  LUKeychainAccessAttrAccessibleAfterFirstUnlockThisDeviceOnly,
-  LUKeychainAccessAttrAccessibleAlways,
-  LUKeychainAccessAttrAccessibleAlwaysThisDeviceOnly,
-  LUKeychainAccessAttrAccessibleWhenUnlocked,
-  LUKeychainAccessAttrAccessibleWhenUnlockedThisDeviceOnly
 };
 
 @interface LUKeychainAccess : NSObject

--- a/LUKeychainAccess/LUKeychainAccessAccessibility.h
+++ b/LUKeychainAccess/LUKeychainAccessAccessibility.h
@@ -1,0 +1,16 @@
+//
+//  LUKeychainAccessAccessibility.h
+//  LUKeychainAccess
+//
+//  Created by Gordon Fontenot on 5/15/15.
+//  Copyright (c) 2015 SCVNGR. All rights reserved.
+//
+
+typedef NS_ENUM(NSInteger, LUKeychainAccessAccessibility) {
+  LUKeychainAccessAttrAccessibleAfterFirstUnlock,
+  LUKeychainAccessAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+  LUKeychainAccessAttrAccessibleAlways,
+  LUKeychainAccessAttrAccessibleAlwaysThisDeviceOnly,
+  LUKeychainAccessAttrAccessibleWhenUnlocked,
+  LUKeychainAccessAttrAccessibleWhenUnlockedThisDeviceOnly
+};

--- a/LUKeychainAccess/LUKeychainServices.h
+++ b/LUKeychainAccess/LUKeychainServices.h
@@ -1,7 +1,7 @@
 // A wrapper for Keychain Services using the Facade pattern: http://en.wikipedia.org/wiki/Facade_pattern
 
 #import <Foundation/Foundation.h>
-#import "LUKeychainAccess.h"
+#import "LUKeychainAccessAccessibility.h"
 
 @interface LUKeychainServices : NSObject
 

--- a/Unit-Tests/LUKeychainAccessSpec.m
+++ b/Unit-Tests/LUKeychainAccessSpec.m
@@ -1,10 +1,9 @@
+@import LUKeychainAccess;
 #import "Kiwi.h"
-#import "LUKeychainAccess.h"
-#import "LUKeychainServices.h"
 #import "LUTestErrorHandler.h"
 
 SPEC_BEGIN(LUKeychainAccessSpec)
-
+  
 describe(@"LUKeychainAccess", ^{
   __block LUKeychainAccess *keychainAccess;
   __block LUKeychainServices *keychainServices;

--- a/Unit-Tests/LUKeychainServicesSpec.m
+++ b/Unit-Tests/LUKeychainServicesSpec.m
@@ -1,5 +1,5 @@
+@import LUKeychainAccess;
 #import "Kiwi.h"
-#import "LUKeychainServices.h"
 
 SPEC_BEGIN(LUKeychainServicesSpec)
 


### PR DESCRIPTION
This adds a framework target, which will allow this project to be built
for use with Git Submodules as well as with Carthage.

- Extracted LUKeychainAccessAccessibility enum to its own file to sever
  a circular import between LUKeychainAccess and LUKeychainServices
- Removed the library target used in testing in favor of a framework
  target. This target is iOS 8+ only, but it hasn't changed the
  deployment target for CocoaPods installation.
- Shared the LUKeychainAccess scheme