### PR TITLE
Synchronizing Keychain items with iCloud

### DIFF
--- a/LUKeychainAccess/LUKeychainAccess.h
+++ b/LUKeychainAccess/LUKeychainAccess.h
@@ -29,6 +29,7 @@ typedef NS_ENUM(NSInteger, LUKeychainAccessError) {
 
 @property (nonatomic, copy) NSString *accessGroup;
 @property (nonatomic, assign) LUKeychainAccessAccessibility accessibilityState;
+@property (nonatomic, assign) BOOL synchronizable;
 @property (nonatomic, strong, nullable) id<LUKeychainErrorHandler> errorHandler;
 @property (nonatomic, copy) NSString *service;
 

--- a/LUKeychainAccess/LUKeychainAccess.m
+++ b/LUKeychainAccess/LUKeychainAccess.m
@@ -81,6 +81,14 @@ NSString *LUKeychainAccessErrorDomain = @"LUKeychainAccessErrorDomain";
   self.keychainServices.service = service;
 }
 
+- (BOOL)synchronizable {
+  return self.keychainServices.synchronizable;
+}
+
+- (void)setSynchronizable:(BOOL)synchronizable {
+  self.keychainServices.synchronizable = synchronizable;
+}
+
 
 
 #pragma mark - Getters

--- a/LUKeychainAccess/LUKeychainServices.h
+++ b/LUKeychainAccess/LUKeychainServices.h
@@ -15,6 +15,7 @@
 
 @property (nonatomic, copy) NSString *accessGroup;
 @property (nonatomic, assign) LUKeychainAccessAccessibility accessibilityState;
+@property (nonatomic, assign) BOOL synchronizable;
 @property (nonatomic, copy) NSString *service;
 
 + (instancetype)keychainServices;

--- a/LUKeychainAccess/LUKeychainServices.m
+++ b/LUKeychainAccess/LUKeychainServices.m
@@ -181,6 +181,10 @@
   NSData *encodedIdentifier = [key dataUsingEncoding:NSUTF8StringEncoding];
   query[(__bridge id)kSecAttrAccount] = encodedIdentifier;
 
+  if (self.synchronizable) {
+    query[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kCFBooleanTrue;
+  }
+
   if (self.service) {
     query[(__bridge id)kSecAttrService] = self.service;
   }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ This option can be set in `LUKeychainAccess` through the `accessibilityState` pa
 
 The default value is `LUKeychainAccessAttrAccessibleWhenUnlocked`.
 
+### Synchronizing Keychain items with iCloud
+
+```objectivec
+LUKeychainAccess *access = [LUKeychainAccess standardKeychainAccess];
+[access setSynchronizable:YES];
+```
+
 ## Error Handling
 
 An instance of `LUKeychainAccess` may be optionally given a error handler, which can be any object that implements the `LUKeychainErrorHandler` protocol. This error handler will be notified if an error occurs.


### PR DESCRIPTION
issue: https://github.com/TheLevelUp/LUKeychainAccess/issues/22

To support iCloud, [kSecAttrSynchronizable](https://developer.apple.com/documentation/security/ksecattrsynchronizable) must be configurable.