### PR TITLE
Add support for additional query parameters

### DIFF
--- a/LUKeychainAccess/LUKeychainAccess.h
+++ b/LUKeychainAccess/LUKeychainAccess.h
@@ -29,6 +29,7 @@ typedef NS_ENUM(NSInteger, LUKeychainAccessError) {
 
 @property (nonatomic, copy) NSString *accessGroup;
 @property (nonatomic, assign) LUKeychainAccessAccessibility accessibilityState;
+@property (nonatomic, strong, nullable) NSDictionary *additionalQueryParams;
 @property (nonatomic, strong, nullable) id<LUKeychainErrorHandler> errorHandler;
 @property (nonatomic, copy) NSString *service;
 

--- a/LUKeychainAccess/LUKeychainAccess.m
+++ b/LUKeychainAccess/LUKeychainAccess.m
@@ -65,12 +65,20 @@ NSString *LUKeychainAccessErrorDomain = @"LUKeychainAccessErrorDomain";
   return self.keychainServices.accessibilityState;
 }
 
+- (NSDictionary *)additionalQueryParams {
+  return self.keychainServices.additionalQueryParams;
+}
+
 - (void)setAccessGroup:(NSString *)accessGroup {
   self.keychainServices.accessGroup = accessGroup;
 }
 
 - (void)setAccessibilityState:(LUKeychainAccessAccessibility)accessibilityState {
   self.keychainServices.accessibilityState = accessibilityState;
+}
+
+- (void)setAdditionalQueryParams:(NSDictionary *)additionalQueryParams {
+  self.keychainServices.additionalQueryParams = additionalQueryParams;
 }
 
 - (NSString *)service {

--- a/LUKeychainAccess/LUKeychainAccessAccessibility.h
+++ b/LUKeychainAccess/LUKeychainAccessAccessibility.h
@@ -10,7 +10,8 @@ typedef NS_ENUM(NSInteger, LUKeychainAccessAccessibility) {
   LUKeychainAccessAttrAccessibleAfterFirstUnlock,
   LUKeychainAccessAttrAccessibleAfterFirstUnlockThisDeviceOnly,
   LUKeychainAccessAttrAccessibleAlways,
+  LUKeychainAccessAttrAccessibleNil,
   LUKeychainAccessAttrAccessibleAlwaysThisDeviceOnly,
   LUKeychainAccessAttrAccessibleWhenUnlocked,
-  LUKeychainAccessAttrAccessibleWhenUnlockedThisDeviceOnly
+  LUKeychainAccessAttrAccessibleWhenUnlockedThisDeviceOnly,
 };

--- a/LUKeychainAccess/LUKeychainServices.h
+++ b/LUKeychainAccess/LUKeychainServices.h
@@ -15,6 +15,7 @@
 
 @property (nonatomic, copy) NSString *accessGroup;
 @property (nonatomic, assign) LUKeychainAccessAccessibility accessibilityState;
+@property (nonatomic, strong) NSDictionary *additionalQueryParams;
 @property (nonatomic, copy) NSString *service;
 
 + (instancetype)keychainServices;

--- a/LUKeychainAccess/LUKeychainServices.m
+++ b/LUKeychainAccess/LUKeychainServices.m
@@ -20,6 +20,7 @@
   if (!self) return nil;
 
   _accessibilityState = LUKeychainAccessAttrAccessibleWhenUnlocked;
+  _additionalQueryParams = nil;
 
   return self;
 }
@@ -111,6 +112,9 @@
     case LUKeychainAccessAttrAccessibleAlways:
       return kSecAttrAccessibleAlways;
 
+    case LUKeychainAccessAttrAccessibleNil:
+      return nil;
+
     case LUKeychainAccessAttrAccessibleAlwaysThisDeviceOnly:
       return kSecAttrAccessibleAlwaysThisDeviceOnly;
 
@@ -185,6 +189,10 @@
     query[(__bridge id)kSecAttrService] = self.service;
   }
 
+  if (self.additionalQueryParams) {
+    [query addEntriesFromDictionary:self.additionalQueryParams];
+  }
+
   if (self.accessGroup) {
 #if TARGET_IPHONE_SIMULATOR
     // Ignore the access group if running on the iPhone simulator.
@@ -199,6 +207,8 @@
     query[(__bridge id)kSecAttrAccessGroup] = self.accessGroup;
 #endif
   }
+
+  NSLog(@"%@", query);
 
   return query;
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES:
   - Kiwi (= 3.0.0)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Kiwi
 
 SPEC CHECKSUMS:
@@ -13,4 +13,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: c005fd22ec0d82b8ddf150a3df1c953eb944280e
 
-COCOAPODS: 1.7.2
+COCOAPODS: 1.10.1

--- a/UnitTests/LUKeychainAccessSpec.m
+++ b/UnitTests/LUKeychainAccessSpec.m
@@ -12,6 +12,7 @@ describe(@"LUKeychainAccess", ^{
   __block LUKeychainServices *keychainServices;
   __block LUTestErrorHandler *errorHandler;
   NSString *testGroup = @"test_group";
+  NSDictionary *testAdditionalParams = @{ @"test":@"test" };
 
   // Helpers
   id (^errorReturningBlock)(NSArray *) = ^id(NSArray *params) {
@@ -97,6 +98,16 @@ describe(@"LUKeychainAccess", ^{
 
     it(@"returns the accessGroup of keychain services", ^{
       [[keychainAccess.accessGroup should] equal:testGroup];
+    });
+  });
+
+  describe(@"additionalQueryParams", ^{
+    beforeEach(^{
+      [keychainServices stub:@selector(additionalQueryParams) andReturn:testAdditionalParams];
+    });
+
+    it(@"returns the additionalQueryParams of keychain services", ^{
+      [[keychainAccess.additionalQueryParams should] equal:testAdditionalParams];
     });
   });
 
@@ -273,6 +284,13 @@ describe(@"LUKeychainAccess", ^{
     it(@"sets the access group on the keychain services", ^{
       [[keychainServices should] receive:@selector(setAccessGroup:) withArguments:testGroup];
       keychainAccess.accessGroup = testGroup;
+    });
+  });
+
+  describe(@"setAdditionalQueryParams:", ^{
+    it(@"sets the additionalQueryParams dictionary on the keychain services", ^{
+      [[keychainServices should] receive:@selector(setAdditionalQueryParams:) withArguments:testAdditionalParams];
+      keychainAccess.additionalQueryParams = testAdditionalParams;
     });
   });
 


### PR DESCRIPTION
This PR enables the ability to support additional query params, such as those requested in issue: #22 but also also allows passing in `kSecUseOperationPrompt` for FaceID/TouchID support